### PR TITLE
Update to use core::error::Error instead of std::error::Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ fn main() -> Result<(), ParseIbanError> {
 
 - A [`Iban`] type that can be used to parse account numbers very quickly. It doesn't require allocations at all, and instead leverages [`arrayvec`](https://crates.io/crates/arrayvec) under the hood.
 - A flexible API that is useful even when the country is not in the Swift registry (using [`BaseIban`]. Instead of using panic, the crate provides typed errors with what went wrong.
-- All functionality can be used in a `no_std` environment (except for the implementation of `std` traits).
+- All functionality can be used in a `no_std` environment.
 - Optional serialization and deserialization via [`serde`](https://crates.io/crates/serde).
 - CI tested results via the Swift provided and custom test cases, as well as proptest.
 - `#![forbid(unsafe_code)]`, making sure all code is written in safe Rust.
@@ -52,7 +52,6 @@ iban_validate = "4"
 
 The following features can be used to configure the crate:
 
-- _std_: **Enabled by default.** Enable the standard library. It is only used to provide implementations of [`Error`](https://doc.rust-lang.org/stable/std/error/trait.Error.html).
 - _serde_: Enable `serde` support for [`Iban`] and [`BaseIban`].
 
 ## Contributing
@@ -61,7 +60,7 @@ If you experience issues with this crate or want to help, please look [here](htt
 
 ## Stability
 
-This crate is usable on the latest stable release of the Rust compiler and otherwise makes no stability guarantees.
+This crate is usable on the latest stable release of the Rust compiler and adheres to semver.
 
 ## License
 

--- a/iban_validate/Cargo.toml
+++ b/iban_validate/Cargo.toml
@@ -20,9 +20,7 @@ name = "iban"
 path = "src/lib.rs"
 
 [features]
-default = ["std"]
-# std is only used for the `Error` trait
-std = []
+default = []
 # Builds rustdoc links, but requires nightly
 intra_rustdoc_links = []
 

--- a/iban_validate/src/base_iban.rs
+++ b/iban_validate/src/base_iban.rs
@@ -1,8 +1,8 @@
 use crate::IbanLike;
 use arrayvec::ArrayString;
-use core::{convert::TryFrom, error::Error};
 use core::fmt;
 use core::str::FromStr;
+use core::{convert::TryFrom, error::Error};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/iban_validate/src/base_iban.rs
+++ b/iban_validate/src/base_iban.rs
@@ -1,6 +1,6 @@
 use crate::IbanLike;
 use arrayvec::ArrayString;
-use core::convert::TryFrom;
+use core::{convert::TryFrom, error::Error};
 use core::fmt;
 use core::str::FromStr;
 #[cfg(feature = "serde")]
@@ -171,10 +171,6 @@ impl fmt::Display for ParseBaseIbanError {
     }
 }
 
-#[cfg(feature = "std")]
-use std::error::Error;
-
-#[cfg(feature = "std")]
 impl Error for ParseBaseIbanError {}
 
 impl BaseIban {

--- a/iban_validate/src/lib.rs
+++ b/iban_validate/src/lib.rs
@@ -5,9 +5,10 @@
 #![deny(bare_trait_objects)]
 #![deny(elided_lifetimes_in_paths)]
 #![deny(missing_debug_implementations)]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 use core::convert::TryFrom;
+use core::error::Error;
 use core::fmt;
 use core::str;
 
@@ -427,10 +428,6 @@ impl fmt::Display for ParseIbanError {
     }
 }
 
-#[cfg(feature = "std")]
-use std::error::Error;
-
-#[cfg(feature = "std")]
 impl Error for ParseIbanError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {

--- a/iban_validate/tests/impls.rs
+++ b/iban_validate/tests/impls.rs
@@ -60,10 +60,8 @@ assert_impl_all!(
     From<ParseBaseIbanError>
 );
 
-#[cfg(feature = "std")]
-assert_impl_all!(ParseBaseIbanError: std::error::Error);
-#[cfg(feature = "std")]
-assert_impl_all!(ParseIbanError: std::error::Error);
+assert_impl_all!(ParseBaseIbanError: core::error::Error);
+assert_impl_all!(ParseIbanError: core::error::Error);
 
 #[cfg(feature = "serde")]
 mod impls_serde {

--- a/iban_validate_registry_generation/src/main.rs
+++ b/iban_validate_registry_generation/src/main.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use std::{fmt::Write, ops::Deref};
+use std::fmt::Write;
 
 use csv::{ReaderBuilder, StringRecord, Trim};
 
@@ -146,7 +146,7 @@ fn generate_bank_identifier_position_in_bban_match_arm(
                     // Remove formatting like spaces and dashes
                     .filter(|c| c.is_ascii_alphanumeric())
                     .collect();
-                if matches!(record.country_code.deref(), "MK" | "SE" | "ST") {
+                if matches!(record.country_code, "MK" | "SE" | "ST") {
                     assert_eq!(bank_identifier_example.len(), bank_identifier_length);
                 } else {
                     // Sometimes the BBAN is just different so we should use the BBAN and not the IBAN. Sometimes the BBAN removes leading zeros or


### PR DESCRIPTION
Since the `Error` trait is now in `core`, the standard library is not needed anymore. This PR updates the error implementation to `core`.